### PR TITLE
Allow using vpaid-flash-client from a project that uses browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,9 @@
     "watchify": "^3.2.1",
     "run-sequence": "^1.1.0"
   },
+  "browserify": {
+    "transform": ["babelify"]
+  },
   "scripts": {
     "start": "gulp serve",
     "test": "gulp test:ci",


### PR DESCRIPTION
Currently the module can't be used from within another project that uses browserify, since you can't browserify a browserified module (See https://github.com/substack/node-browserify/pull/1151)

Adding the option below to package.json allows including the raw javascript, allowing the requiring module to handle the browserification.
To include the module with require you should

npm install vpaid-html5-client

and then include it like this:

var VPAIDHTML5Client = require('vpaid-html5-client/js/VPAIDHTML5Client.js');